### PR TITLE
Keep amazon-vpc-cni-k8s up to date

### DIFF
--- a/ci/deploy.yml
+++ b/ci/deploy.yml
@@ -6,6 +6,7 @@ image_resource:
     repository: govau/cga-cli
     tag: latest
 inputs:
+- name: amazon-vpc-cni-k8s
 - name: aws-servicebroker
 - name: charts
 - name: deploy-src

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,5 +1,12 @@
 groups: []
 resources:
+- name: amazon-vpc-cni-k8s
+  type: github-release
+  icon: github-circle
+  source:
+    access_token: ((github-public-repo-personal-access-token))
+    owner: aws
+    repository: amazon-vpc-cni-k8s
 - name: aws-servicebroker
   type: github-release
   icon: github-circle
@@ -142,6 +149,9 @@ jobs:
   - k
   plan:
   - do:
+    - get: amazon-vpc-cni-k8s
+      include_source_tarball: true
+      trigger: true
     - get: aws-servicebroker
       trigger: true
     - get: ops
@@ -253,6 +263,8 @@ jobs:
   - l
   plan:
   - do:
+    - get: amazon-vpc-cni-k8s
+      include_source_tarball: true
     - get: aws-servicebroker
       passed:
       - deploy-k


### PR DESCRIPTION
As we noticed today, eks seems to add the latest version of amazon-vpc-cni-k8s to a new cluster on creation, and never updates it. Since k-cld is recreated each day this meant k-cld and l-cld had drifted over time. This change ensures they stay together with the version returned from the github release.